### PR TITLE
Fix confusing constant name

### DIFF
--- a/lurker/constants/constants.go
+++ b/lurker/constants/constants.go
@@ -23,7 +23,7 @@ J6JqDBl5e3S7KOhvci76QtWfR/TrNyU9tv8Wz8wqe9kovpHNpVzUNJvVUQIDAQAB
 	UseProxy                    = false
 	Proxy                       = "127.0.0.1:8080"
 	SleepTime                   = 10000 * time.Millisecond
-	VerifySSLCert               = true
+	IgnoreSSLCertErrors         = true
 	TimeOut       time.Duration = 10 //seconds
 
 	IV        = []byte("abcdefghijklmnop")

--- a/lurker/transports/http.go
+++ b/lurker/transports/http.go
@@ -22,7 +22,7 @@ func init() {
 	trans.MaxIdleConns = 20
 	trans.TLSHandshakeTimeout = constants.TimeOut * time.Second
 	trans.DisableKeepAlives = true
-	trans.TLSClientConfig = &tls.Config{InsecureSkipVerify: constants.VerifySSLCert}
+	trans.TLSClientConfig = &tls.Config{InsecureSkipVerify: constants.IgnoreSSLCertErrors}
 }
 
 func HttpPost(url string, clientID string, data []byte) *req.Resp {


### PR DESCRIPTION
Currently the constant is called "VerifySSLCert" and by default is set to true. That makes it sound like it verifies if SSL certificates are valid and only allows valid SSL certificates, which is not the case. How this is referenced in the code elsewhere in transports/http.go - "true" means to ignore any SSL certificate validation errors. Kept the default behavior of ignore invalid SSL certificates and continue by simply changing the constant name to be more accurate.