### PR TITLE
Forgot one

### DIFF
--- a/lurker/transports/http.go
+++ b/lurker/transports/http.go
@@ -39,7 +39,7 @@ func init() {
 		TLSHandshakeTimeout: constants.TimeOut * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: constants.VerifySSLCert,
+			InsecureSkipVerify: constants.IgnoreSSLCertErrors,
 		},
 	}
 	


### PR DESCRIPTION
Forgot an instance of VerifySSLCert that needed to be swapped to the newer, less confusing IgnoreSSLCertErrors, sorry.